### PR TITLE
Styling default plain request and response data

### DIFF
--- a/assets/css/shared/shared-style.scss
+++ b/assets/css/shared/shared-style.scss
@@ -5,6 +5,7 @@
 @import "../variables";
 
 .sophi {
+
 	&-request {
 		background-color: $white;
 		margin: 1em 0;
@@ -27,8 +28,6 @@
 			padding-top: 1em;
 
 			& > div {
-				display: inline-block;
-				width: 50%;
 				flex-basis: 50%;
 
 				&:first-child {
@@ -43,10 +42,11 @@
 	}
 
 	&-json-view {
+
 		& > pre {
+			background-color: rgba(0, 0, 0, 0.05);
 			white-space: pre-wrap;
 			word-wrap: break-word;
-			background-color: rgba(0, 0, 0, 0.05);
 		}
 	}
 }

--- a/assets/css/shared/shared-style.scss
+++ b/assets/css/shared/shared-style.scss
@@ -4,37 +4,49 @@
  */
 @import "../variables";
 
-.sophi-request {
-	background-color: $white;
-	margin: 1em 0;
-	padding: 1em;
+.sophi {
+	&-request {
+		background-color: $white;
+		margin: 1em 0;
+		padding: 1em;
 
-	&-header {
-		display: flex;
+		&-header {
+			display: flex;
 
-		&-item {
-			padding: 0 1em 0 0;
+			&-item {
+				padding: 0 1em 0 0;
 
-			&:last-child {
-				padding: 0;
+				&:last-child {
+					padding: 0;
+				}
 			}
+		}
+
+		&-details {
+			display: flex;
+			padding-top: 1em;
+
+			& > div {
+				display: inline-block;
+				width: 50%;
+				flex-basis: 50%;
+
+				&:first-child {
+					padding-right: 1em;
+				}
+			}
+		}
+
+		&-error {
+			background-color: $error;
 		}
 	}
 
-	&-details {
-		display: flex;
-		padding-top: 1em;
-
-		& > div {
-			flex: 0 0 50%;
-
-			&:first-child {
-				padding-right: 1em;
-			}
+	&-json-view {
+		& > pre {
+			white-space: pre-wrap;
+			word-wrap: break-word;
+			background-color: rgba(0, 0, 0, 0.05);
 		}
-	}
-
-	&-error {
-		background-color: $error;
 	}
 }

--- a/includes/class-sophi-debug-bar-panel.php
+++ b/includes/class-sophi-debug-bar-panel.php
@@ -136,13 +136,13 @@ class SophiDebugBarPanel extends \Debug_Bar_Panel {
 						<div>
 							<strong><?php esc_html_e( 'Request', 'debug-bar-for-sophi' ); ?></strong>
 							<div class="sophi-json-view" id="sophi-request-body-<?php echo esc_attr( $key ); ?>">
-								<?php echo esc_attr( $request->get_request_body() ); ?>
+								<pre><?php echo esc_attr( $request->get_request_body() ); ?></pre>
 							</div>
 						</div>
 						<div>
 							<strong><?php esc_html_e( 'Response', 'debug-bar-for-sophi' ); ?></strong>
 							<div class="sophi-json-view" id="sophi-response-body-<?php echo esc_attr( $key ); ?>">
-								<?php echo esc_attr( $request->get_response_body() ); ?>
+								<pre><?php echo esc_attr( $request->get_response_body() ); ?></pre>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
### Description of the Change

When Request or Response body is not a valid JSON string, the JSON Viewer will refuse to display the expandable view and keep plain output inside `<pre>` with CSS to wrap text.

Closes #22 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Fix - Debug records horizontal overflow

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic
