### PR TITLE
Fix linting workflow trigger list

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,11 @@ jobs:
         uses: tj-actions/changed-files@v18.7
         with:
           files: |
+            package.json
+            package-lock.json
+            .eslintignore
+            .eslintrc.json
+            phpcs.xml
             **/*.css
             **/*.js
             **/*.php

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-    "*.css": [
+    "*.{css,scss}": [
       "10up-toolkit lint-style"
     ],
     "*.js": [

--- a/assets/css/shared/shared-style.scss
+++ b/assets/css/shared/shared-style.scss
@@ -44,7 +44,7 @@
 	&-json-view {
 
 		& > pre {
-			background-color: rgba(0, 0, 0, 0.05);
+			background-color: rgba(0 0 0 / 5%);
 			white-space: pre-wrap;
 			word-wrap: break-word;
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1934,6 +1934,26 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@csstools/postcss-cascade-layers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-1.0.1.tgz",
+      "integrity": "sha512-IpGtKHZ6XFj2cpRp9i45V/+fpcPv/W6Eybw7sFpqyVeCEH7UttHhrbop6JACESOhOYc/onTRb3tchHo/g3K4TA==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/selector-specificity": "^1.0.0",
+        "postcss-selector-parser": "^6.0.10"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3"
+      }
+    },
     "node_modules/@csstools/postcss-color-function": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.1.0.tgz",
@@ -7329,25 +7349,25 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.29.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.4.tgz",
-      "integrity": "sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==",
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
+      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flatmap": "^1.2.5",
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.0",
+        "object.hasown": "^1.1.1",
         "object.values": "^1.1.5",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.6"
+        "string.prototype.matchall": "^4.0.7"
       },
       "engines": {
         "node": ">=4"
@@ -13568,22 +13588,23 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.5.0.tgz",
-      "integrity": "sha512-0BJzWEfCdTtK2R3EiKKSdkE51/DI/BwnhlnicSW482Ym6/DGHud8K0wGLcdjip1epVX0HKo4c8zzTeV/SkiejQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.6.0.tgz",
+      "integrity": "sha512-5cnzpSFZnQJOlBu85xn4Nnluy/WjIST/ugn+gOVcKnmFJ+GLtkfRhmJPo/TW9UDpG7oyA467kvDOO8mtcpOL4g==",
       "dev": true,
       "dependencies": {
+        "@csstools/postcss-cascade-layers": "^1.0.1",
         "@csstools/postcss-color-function": "^1.1.0",
         "@csstools/postcss-font-format-keywords": "^1.0.0",
-        "@csstools/postcss-hwb-function": "^1.0.0",
+        "@csstools/postcss-hwb-function": "^1.0.1",
         "@csstools/postcss-ic-unit": "^1.0.0",
-        "@csstools/postcss-is-pseudo-class": "^2.0.2",
+        "@csstools/postcss-is-pseudo-class": "^2.0.4",
         "@csstools/postcss-normalize-display-values": "^1.0.0",
         "@csstools/postcss-oklab-function": "^1.1.0",
         "@csstools/postcss-progressive-custom-properties": "^1.3.0",
         "@csstools/postcss-stepped-value-functions": "^1.0.0",
-        "@csstools/postcss-unset-value": "^1.0.0",
-        "autoprefixer": "^10.4.6",
+        "@csstools/postcss-unset-value": "^1.0.1",
+        "autoprefixer": "^10.4.7",
         "browserslist": "^4.20.3",
         "css-blank-pseudo": "^3.0.3",
         "css-has-pseudo": "^3.0.4",
@@ -13609,12 +13630,12 @@
         "postcss-lab-function": "^4.2.0",
         "postcss-logical": "^5.0.4",
         "postcss-media-minmax": "^5.0.0",
-        "postcss-nesting": "^10.1.4",
+        "postcss-nesting": "^10.1.6",
         "postcss-opacity-percentage": "^1.1.2",
         "postcss-overflow-shorthand": "^3.0.3",
         "postcss-page-break": "^3.0.4",
         "postcss-place": "^7.0.4",
-        "postcss-pseudo-class-any-link": "^7.1.2",
+        "postcss-pseudo-class-any-link": "^7.1.4",
         "postcss-replace-overflow-wrap": "^4.0.0",
         "postcss-selector-not": "^5.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -18609,6 +18630,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@csstools/postcss-cascade-layers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-1.0.1.tgz",
+      "integrity": "sha512-IpGtKHZ6XFj2cpRp9i45V/+fpcPv/W6Eybw7sFpqyVeCEH7UttHhrbop6JACESOhOYc/onTRb3tchHo/g3K4TA==",
+      "dev": true,
+      "requires": {
+        "@csstools/selector-specificity": "^1.0.0",
+        "postcss-selector-parser": "^6.0.10"
+      }
+    },
     "@csstools/postcss-color-function": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.1.0.tgz",
@@ -22714,25 +22745,25 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.29.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.4.tgz",
-      "integrity": "sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==",
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
+      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flatmap": "^1.2.5",
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.0",
+        "object.hasown": "^1.1.1",
         "object.values": "^1.1.5",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.6"
+        "string.prototype.matchall": "^4.0.7"
       },
       "dependencies": {
         "doctrine": {
@@ -27114,22 +27145,23 @@
       }
     },
     "postcss-preset-env": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.5.0.tgz",
-      "integrity": "sha512-0BJzWEfCdTtK2R3EiKKSdkE51/DI/BwnhlnicSW482Ym6/DGHud8K0wGLcdjip1epVX0HKo4c8zzTeV/SkiejQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.6.0.tgz",
+      "integrity": "sha512-5cnzpSFZnQJOlBu85xn4Nnluy/WjIST/ugn+gOVcKnmFJ+GLtkfRhmJPo/TW9UDpG7oyA467kvDOO8mtcpOL4g==",
       "dev": true,
       "requires": {
+        "@csstools/postcss-cascade-layers": "^1.0.1",
         "@csstools/postcss-color-function": "^1.1.0",
         "@csstools/postcss-font-format-keywords": "^1.0.0",
-        "@csstools/postcss-hwb-function": "^1.0.0",
+        "@csstools/postcss-hwb-function": "^1.0.1",
         "@csstools/postcss-ic-unit": "^1.0.0",
-        "@csstools/postcss-is-pseudo-class": "^2.0.2",
+        "@csstools/postcss-is-pseudo-class": "^2.0.4",
         "@csstools/postcss-normalize-display-values": "^1.0.0",
         "@csstools/postcss-oklab-function": "^1.1.0",
         "@csstools/postcss-progressive-custom-properties": "^1.3.0",
         "@csstools/postcss-stepped-value-functions": "^1.0.0",
-        "@csstools/postcss-unset-value": "^1.0.0",
-        "autoprefixer": "^10.4.6",
+        "@csstools/postcss-unset-value": "^1.0.1",
+        "autoprefixer": "^10.4.7",
         "browserslist": "^4.20.3",
         "css-blank-pseudo": "^3.0.3",
         "css-has-pseudo": "^3.0.4",
@@ -27155,12 +27187,12 @@
         "postcss-lab-function": "^4.2.0",
         "postcss-logical": "^5.0.4",
         "postcss-media-minmax": "^5.0.0",
-        "postcss-nesting": "^10.1.4",
+        "postcss-nesting": "^10.1.6",
         "postcss-opacity-percentage": "^1.1.2",
         "postcss-overflow-shorthand": "^3.0.3",
         "postcss-page-break": "^3.0.4",
         "postcss-place": "^7.0.4",
-        "postcss-pseudo-class-any-link": "^7.1.2",
+        "postcss-pseudo-class-any-link": "^7.1.4",
         "postcss-replace-overflow-wrap": "^4.0.0",
         "postcss-selector-not": "^5.0.0",
         "postcss-value-parser": "^4.2.0"


### PR DESCRIPTION
### Description of the Change

After upgrading 10up-toolkit to 4.0.0 in #31 some new rules were applied to stylelint, which is now causing linting errors in new PRs (#27, #32, #33).

In #31 actions, the linting job was skipped because no source files were changed.

This PR adds more sensitive files to the trigger list:
- package.json and lockfile
- eslint config
- phpcs config

It will force linting job to run when the config changes even if no source files were changed (like it happened in #31)

### Verification Process

- At https://github.com/10up/sophi-debug-bar/pull/34/commits/2e932fe1454b95e570aeead129d9f52a52098ef5 lint job [executes with failure](https://github.com/10up/sophi-debug-bar/runs/6508131496?check_suite_focus=true) if package-lock.json changed, no source files
- At https://github.com/10up/sophi-debug-bar/pull/34/commits/7c9b674829cf1263e636fb3401eeb40fa02ac55a lint job [succeeds](https://github.com/10up/sophi-debug-bar/runs/6508357550?check_suite_focus=true) after SCSS fix applied

### Related issues/PRs

After this is merged, perform merge `develop` into #27, #32 and #33 to resolve GitHub Actions failure.